### PR TITLE
docs: sync SKETCHES.md §1.1 dimensions to DESIGN-multi-uav.md (Closes #17)

### DIFF
--- a/docs/SKETCHES.md
+++ b/docs/SKETCHES.md
@@ -22,8 +22,8 @@
 
 $\mathcal{M} = (\mathcal{S}, \mathcal{A}, P, \mathbf{r}, \gamma)$ where:
 
-- **State**:
-  $\mathbf{s}(t) = \big[\{\mathbf{q}_m, \mathbf{v}_m\}_{m=1}^M, \{\Delta\mathbf{q}_{m,k}, A_k, g_{m,k}\}, \{\tau_k\}, t/T\big] \in \mathbb{R}^{(2M+3MK)+K+1}$.
+- **State** (canonical formulation, see `docs/DESIGN-multi-uav.md` §1.1):
+  $\mathbf{s}(t) = \big[\{\mathbf{q}_m, \mathbf{v}_m\}_{m=1}^M, \{\Delta\mathbf{q}_{m,k}, A_k, g_{m,k}\}, \{\tau_k\}, t/T\big] \in \mathbb{R}^{6M + 3MK + 2K + 1}$ (e.g., $M=5, K=20 \Rightarrow 371$).
 
 - **Action**:
   $\mathbf{a}(t) = \big[\{\boldsymbol{\nu}_m, \mathbf{p}_m, \boldsymbol{\eta}_m, \mathbf{x}_m\}_{m=1}^M\big]$ with per-UAV acceleration, transmit power, compression ratios, and binary scheduling vector $\mathbf{x}_m \in \{0,1\}^K$.


### PR DESCRIPTION
Tiny doc sync. Closes #17.

DESIGN-multi-uav.md §1.1 is the canonical formulation. SKETCHES.md was the older first-cut sketch with two dimensional errors:

- Kinematics block: `2M` → `6M` (3-D position + 3-D velocity per UAV)
- Post-MK block: `K+1` → `2K+1` (AoSI per device adds K, plus normalised time scalar)

This PR fixes the formula and adds the M=5/K=20=371 example to mirror DESIGN-multi-uav.md.

Closes #17