### PR TITLE
feat(baselines): MO-PPO baseline (Issue #8 PR-C, draft)

### DIFF
--- a/baselines/__init__.py
+++ b/baselines/__init__.py
@@ -56,3 +56,4 @@ __all__ = [
 # without any further setup. Each external baseline added in a later PR will
 # register itself by importing it here.
 from . import noop  # noqa: F401
+from . import mo_ppo  # noqa: F401  -- registers "mo-ppo"

--- a/baselines/_morl_eval.py
+++ b/baselines/_morl_eval.py
@@ -1,0 +1,57 @@
+"""Lightweight MORL eval helpers used by external baselines.
+
+The original agent.py defines ``generate_w_batch_test`` and
+``evluate_Hv_UT_and_spa`` but importing it pulls in heavy training-only
+dependencies (tensorboard, visdom, rltorch). Baselines only need the
+preference grid + HV metric, so this module re-implements those two
+functions with the smallest possible dependency footprint (numpy +
+the existing hypervolume.py).
+"""
+from __future__ import annotations
+
+import itertools
+from copy import deepcopy
+
+import numpy as np
+
+from hypervolume import InnerHyperVolume
+
+
+def generate_w_batch_test(reward_num: int, step_size: float) -> np.ndarray:
+    """Uniform simplex grid; matches agent.py:262 verbatim."""
+    mesh_array = [np.arange(0, 1 + step_size, step_size) for _ in range(reward_num)]
+    w_batch_test = np.array(list(itertools.product(*mesh_array)))
+    w_batch_test = w_batch_test[w_batch_test.sum(axis=1) == 1, :]
+    w_batch_test = np.unique(w_batch_test, axis=0)
+    return w_batch_test
+
+
+def _sparsity(obj_batch: np.ndarray) -> float:
+    if len(obj_batch) <= 1:
+        return 0.0
+    sparsity = 0.0
+    m = len(obj_batch[0])
+    for dim in range(m):
+        objs_i = np.sort(deepcopy(obj_batch.T[dim]))
+        for i in range(1, len(objs_i)):
+            sparsity += np.square(objs_i[i] - objs_i[i - 1])
+    return float(sparsity / max(len(obj_batch) - 1, 1))
+
+
+def evluate_Hv_UT_and_spa(
+    obj_num: int, obj_batch: np.ndarray, PREF_: np.ndarray
+) -> tuple:
+    """Mirrors agent.py:145 — HV against zero ref point, mean utility over
+    PREF_, and sparsity. Returns (hv, sparsity, ut). Spelling matches the
+    original codebase to keep call sites identical (it's "evaluate" with a
+    typo in agent.py)."""
+    obj_batch = np.asarray(obj_batch, dtype=np.float64)
+    ref_point = np.zeros(obj_num)
+    HV = InnerHyperVolume(-ref_point)
+    hv = HV.compute(obj_batch)
+    sparsity = _sparsity(obj_batch)
+    ut = 0.0
+    for ref in PREF_:
+        ut += float(np.max(np.sum(np.array(ref) * obj_batch, axis=-1)))
+    ut /= max(len(PREF_), 1)
+    return hv, sparsity, ut

--- a/baselines/mo_ppo.py
+++ b/baselines/mo_ppo.py
@@ -1,0 +1,396 @@
+"""MO-PPO baseline (Issue #8 PR-C).
+
+Vanilla weighted-sum scalarized PPO with a preference-conditioned policy and a
+vector critic (one head per objective). This is the "vanilla MORL" comparison
+point every TWC reviewer expects: standard PPO machinery, no COR, no OADM, no
+constraint handler — only the preference vector and a multi-headed value
+function distinguish it from single-objective PPO.
+
+Default scalarisation: weighted-sum (DESIGN-baselines.md §7 Q2 default). The
+Tchebycheff variant is left as a deferred ablation.
+
+Architectural choices (all standard PPO knobs unless noted):
+
+    Actor:  MLP(state ⊕ preference) → mean, log_std (state-independent log_std,
+            shared parameter, initialised to log(0.5)). Tanh squashing on
+            sampled action.
+    Critic: MLP(state ⊕ preference) → N scalar values. The scalarised
+            advantage that drives the policy update is `w^T A_vec`.
+    Buffer: on-policy rollout buffer, GAE(λ=0.95) on each per-objective
+            advantage, clipped surrogate objective.
+    Update: minibatch SGD over the rollout for K epochs.
+
+Eval:
+    Every `eval_interval` env steps, evaluate the deterministic mean policy at
+    each of the 56 fixed preferences (the existing
+    `generate_w_batch_test(N=4, step=0.2)` grid). Collect the 4-D episode return
+    per preference, compute hypervolume / utility / sparsity via the existing
+    `evluate_Hv_UT_and_spa` helper from `agent.py`. This matches the
+    SemMORL eval protocol exactly.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Optional, Dict, Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Normal
+
+# Re-implementations of the SemMORL eval helpers; dependency-light so we
+# don't pull tensorboard/visdom/rltorch through the heavy agent.py.
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+from ._morl_eval import evluate_Hv_UT_and_spa, generate_w_batch_test
+
+from .base import Baseline
+from .registry import register_baseline
+
+
+def mlp(sizes, act=nn.Tanh, output_act=None):
+    layers = []
+    for i in range(len(sizes) - 1):
+        layers.append(nn.Linear(sizes[i], sizes[i + 1]))
+        if i < len(sizes) - 2:
+            layers.append(act())
+        elif output_act is not None:
+            layers.append(output_act())
+    return nn.Sequential(*layers)
+
+
+class PPOActor(nn.Module):
+    """Preference-conditioned Gaussian policy with state-independent log_std."""
+
+    def __init__(self, state_dim: int, pref_dim: int, action_dim: int,
+                 hidden=(64, 64)):
+        super().__init__()
+        self.body = mlp([state_dim + pref_dim, *hidden, action_dim])
+        # Shared log_std parameter — standard PPO convention.
+        self.log_std = nn.Parameter(torch.full((action_dim,), float(np.log(0.5))))
+
+    def forward(self, state: torch.Tensor, pref: torch.Tensor):
+        mean = self.body(torch.cat([state, pref], dim=-1))
+        std = self.log_std.exp().expand_as(mean)
+        return Normal(mean, std)
+
+    def act(self, state: torch.Tensor, pref: torch.Tensor, deterministic: bool = False):
+        dist = self.forward(state, pref)
+        if deterministic:
+            action = dist.mean
+        else:
+            action = dist.sample()
+        # Tanh squash to [-1, 1] then env's max_action handled outside.
+        squashed = torch.tanh(action)
+        # log_prob with tanh correction: log p(u) - sum log(1 - tanh(u)^2 + 1e-6)
+        logp = dist.log_prob(action).sum(-1) - torch.log(
+            1 - squashed.pow(2) + 1e-6
+        ).sum(-1)
+        return squashed, logp, action  # raw action retained for re-evaluation
+
+    def evaluate(self, state, pref, raw_action):
+        dist = self.forward(state, pref)
+        squashed = torch.tanh(raw_action)
+        logp = dist.log_prob(raw_action).sum(-1) - torch.log(
+            1 - squashed.pow(2) + 1e-6
+        ).sum(-1)
+        entropy = dist.entropy().sum(-1)
+        return logp, entropy
+
+
+class PPOVectorCritic(nn.Module):
+    """One scalar value head per objective. Output shape (B, N)."""
+
+    def __init__(self, state_dim: int, pref_dim: int, N: int, hidden=(64, 64)):
+        super().__init__()
+        self.body = mlp([state_dim + pref_dim, *hidden, N])
+
+    def forward(self, state, pref):
+        return self.body(torch.cat([state, pref], dim=-1))
+
+
+class RolloutBuffer:
+    """Fixed-size on-policy buffer. Per-objective advantages computed via GAE."""
+
+    def __init__(self, T: int, state_dim: int, action_dim: int,
+                 pref_dim: int, N: int, gamma: float, gae_lambda: float):
+        self.T = T
+        self.N = N
+        self.gamma = gamma
+        self.gae_lambda = gae_lambda
+        self.states = np.zeros((T, state_dim), dtype=np.float32)
+        self.prefs = np.zeros((T, pref_dim), dtype=np.float32)
+        self.raw_actions = np.zeros((T, action_dim), dtype=np.float32)
+        self.squashed_actions = np.zeros((T, action_dim), dtype=np.float32)
+        self.logp = np.zeros(T, dtype=np.float32)
+        self.rewards = np.zeros((T, N), dtype=np.float32)
+        self.values = np.zeros((T, N), dtype=np.float32)
+        self.dones = np.zeros(T, dtype=np.float32)
+        self.advantages = np.zeros((T, N), dtype=np.float32)
+        self.returns = np.zeros((T, N), dtype=np.float32)
+        self.ptr = 0
+
+    def add(self, state, pref, raw_action, squashed_action, logp, reward,
+            value, done):
+        i = self.ptr
+        self.states[i] = state
+        self.prefs[i] = pref
+        self.raw_actions[i] = raw_action
+        self.squashed_actions[i] = squashed_action
+        self.logp[i] = logp
+        self.rewards[i] = reward
+        self.values[i] = value
+        self.dones[i] = done
+        self.ptr += 1
+
+    def finish(self, last_value: np.ndarray):
+        """GAE on each objective independently. last_value shape (N,)."""
+        T, N = self.ptr, self.N
+        adv = np.zeros((T, N), dtype=np.float32)
+        last_gae = np.zeros(N, dtype=np.float32)
+        for t in reversed(range(T)):
+            next_value = (
+                last_value if t == T - 1 else self.values[t + 1]
+            )
+            next_nonterminal = 1.0 - self.dones[t]
+            delta = (
+                self.rewards[t] + self.gamma * next_value * next_nonterminal
+                - self.values[t]
+            )
+            last_gae = delta + self.gamma * self.gae_lambda * next_nonterminal * last_gae
+            adv[t] = last_gae
+        self.advantages[:T] = adv
+        self.returns[:T] = adv + self.values[:T]
+
+    def reset(self):
+        self.ptr = 0
+
+
+def _sample_pref(rng: np.random.RandomState, N: int) -> np.ndarray:
+    p = rng.rand(N).astype(np.float32)
+    p /= p.sum()
+    return p
+
+
+@register_baseline("mo-ppo")
+class MoPPOBaseline(Baseline):
+    """Weighted-sum scalarized PPO with preference-conditioned policy."""
+
+    name = "mo-ppo"
+
+    def __init__(self, env, log_dir: str, seed: int,
+                 method_kwargs: Optional[Dict[str, Any]] = None):
+        super().__init__(env, log_dir, seed, method_kwargs)
+        mk = self.method_kwargs
+
+        self.gamma = float(mk.get("gamma", 0.99))
+        self.gae_lambda = float(mk.get("gae_lambda", 0.95))
+        self.lr = float(mk.get("lr", 3e-4))
+        self.clip_eps = float(mk.get("clip_eps", 0.2))
+        self.entropy_coef = float(mk.get("entropy_coef", 0.0))
+        self.value_coef = float(mk.get("value_coef", 0.5))
+        self.rollout_T = int(mk.get("rollout_T", 2048))
+        self.minibatch_size = int(mk.get("minibatch_size", 64))
+        self.update_epochs = int(mk.get("update_epochs", 10))
+        self.hidden = tuple(mk.get("hidden", (64, 64)))
+        self.eval_episodes_per_pref = int(mk.get("eval_episodes_per_pref", 1))
+        self.device = torch.device(mk.get("device", "cpu"))
+
+        self.state_dim = env.observation_space.shape[0]
+        self.action_dim = env.action_space.shape[0]
+        self.pref_dim = int(getattr(env, "reward_num", 4))
+        self.N = self.pref_dim
+        self.max_action = env.action_space.high
+
+        torch.manual_seed(self.seed)
+        np.random.seed(self.seed)
+
+        self.actor = PPOActor(
+            self.state_dim, self.pref_dim, self.action_dim, hidden=self.hidden
+        ).to(self.device)
+        self.critic = PPOVectorCritic(
+            self.state_dim, self.pref_dim, self.N, hidden=self.hidden
+        ).to(self.device)
+        self.opt = torch.optim.Adam(
+            list(self.actor.parameters()) + list(self.critic.parameters()),
+            lr=self.lr,
+        )
+        self.rng = np.random.RandomState(self.seed)
+        # Pre-generate the preference grid used at eval time so HV is comparable
+        # to the SemMORL eval protocol.
+        step_map = {3: 0.05, 4: 0.2, 5: 0.25}
+        step = step_map.get(self.N, 0.2)
+        self.eval_prefs = generate_w_batch_test(self.N, step_size=step)
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+    def train(self, num_steps: int, eval_interval: int, our_wandb=None) -> None:
+        T = self.rollout_T
+        buf = RolloutBuffer(
+            T=T, state_dim=self.state_dim, action_dim=self.action_dim,
+            pref_dim=self.pref_dim, N=self.N,
+            gamma=self.gamma, gae_lambda=self.gae_lambda,
+        )
+
+        env = self.env
+        env.seed(self.seed)
+        state = env.reset()
+        cur_pref = _sample_pref(self.rng, self.N)
+        steps = 0
+        t0 = time.time()
+        next_eval = eval_interval
+
+        while steps < num_steps:
+            buf.reset()
+            for _ in range(T):
+                s_t = torch.as_tensor(state, dtype=torch.float32,
+                                      device=self.device).unsqueeze(0)
+                p_t = torch.as_tensor(cur_pref, dtype=torch.float32,
+                                      device=self.device).unsqueeze(0)
+                with torch.no_grad():
+                    squashed, logp, raw = self.actor.act(s_t, p_t)
+                    value = self.critic(s_t, p_t)
+                a_squashed = squashed.cpu().numpy().reshape(-1)
+                a_raw = raw.cpu().numpy().reshape(-1)
+                action_env = a_squashed * self.max_action
+                next_state, reward, done, _ = env.step(action_env)
+                buf.add(
+                    state=state, pref=cur_pref,
+                    raw_action=a_raw, squashed_action=a_squashed,
+                    logp=float(logp.cpu().item()),
+                    reward=np.asarray(reward, dtype=np.float32),
+                    value=value.cpu().numpy().reshape(-1),
+                    done=float(done),
+                )
+                state = next_state
+                steps += 1
+                if done:
+                    state = env.reset()
+                    cur_pref = _sample_pref(self.rng, self.N)
+                if steps >= num_steps:
+                    break
+                if steps >= next_eval:
+                    self._evaluate(steps)
+                    next_eval += eval_interval
+
+            # Bootstrap last value for GAE
+            with torch.no_grad():
+                last_v = self.critic(
+                    torch.as_tensor(state, dtype=torch.float32,
+                                    device=self.device).unsqueeze(0),
+                    torch.as_tensor(cur_pref, dtype=torch.float32,
+                                    device=self.device).unsqueeze(0),
+                ).cpu().numpy().reshape(-1)
+            buf.finish(last_v)
+            self._update(buf)
+
+        # Final eval if we haven't already covered the last interval.
+        if not self.eval_steps or self.eval_steps[-1] < num_steps:
+            self._evaluate(num_steps)
+
+        # Populate final-state buffers from the most recent eval episodes.
+        self._populate_final_buffers()
+        self.wallclock_seconds = time.time() - t0
+
+    def _update(self, buf: RolloutBuffer) -> None:
+        T = buf.ptr
+        idxs = np.arange(T)
+        states = torch.as_tensor(buf.states[:T], device=self.device)
+        prefs = torch.as_tensor(buf.prefs[:T], device=self.device)
+        raw_act = torch.as_tensor(buf.raw_actions[:T], device=self.device)
+        old_logp = torch.as_tensor(buf.logp[:T], device=self.device)
+        adv_vec = torch.as_tensor(buf.advantages[:T], device=self.device)
+        ret_vec = torch.as_tensor(buf.returns[:T], device=self.device)
+        # Scalarised advantage drives the policy update.
+        adv_scalar = (adv_vec * prefs).sum(-1)
+        # Per-rollout normalisation (standard PPO trick).
+        adv_scalar = (adv_scalar - adv_scalar.mean()) / (adv_scalar.std() + 1e-8)
+
+        for _ in range(self.update_epochs):
+            self.rng.shuffle(idxs)
+            for start in range(0, T, self.minibatch_size):
+                mb = idxs[start:start + self.minibatch_size]
+                mb_t = torch.as_tensor(mb, dtype=torch.long, device=self.device)
+                logp, entropy = self.actor.evaluate(
+                    states[mb_t], prefs[mb_t], raw_act[mb_t]
+                )
+                ratio = (logp - old_logp[mb_t]).exp()
+                surr1 = ratio * adv_scalar[mb_t]
+                surr2 = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps) \
+                        * adv_scalar[mb_t]
+                actor_loss = -torch.min(surr1, surr2).mean()
+                values = self.critic(states[mb_t], prefs[mb_t])
+                critic_loss = F.mse_loss(values, ret_vec[mb_t])
+                loss = (actor_loss + self.value_coef * critic_loss
+                        - self.entropy_coef * entropy.mean())
+                self.opt.zero_grad()
+                loss.backward()
+                self.opt.step()
+
+    # ------------------------------------------------------------------
+    # Eval
+    # ------------------------------------------------------------------
+    def _evaluate(self, step: int) -> None:
+        objs = []
+        for pref in self.eval_prefs:
+            ep_obj = self._eval_episode(pref)
+            objs.append(ep_obj)
+        objs = np.asarray(objs, dtype=np.float64)
+        hv, sparsity, ut = evluate_Hv_UT_and_spa(self.N, objs, self.eval_prefs)
+        self._record_eval(step=step, hv=hv, ut=ut, sparsity=sparsity)
+        self._last_eval_objs = objs
+        self._last_eval_prefs = np.asarray(self.eval_prefs, dtype=np.float64)
+
+    def _eval_episode(self, preference: np.ndarray) -> np.ndarray:
+        """Run one deterministic episode at the given preference; return the
+        4-D summed reward."""
+        ep_obj = np.zeros(self.N, dtype=np.float64)
+        # Use a separate seed offset to avoid eval-train state collision.
+        self.env.seed(self.seed + 1_000_000 + int(preference[0] * 1e6))
+        state = self.env.reset()
+        done = False
+        with torch.no_grad():
+            while not done:
+                s_t = torch.as_tensor(state, dtype=torch.float32,
+                                      device=self.device).unsqueeze(0)
+                p_t = torch.as_tensor(preference, dtype=torch.float32,
+                                      device=self.device).unsqueeze(0)
+                squashed, _, _ = self.actor.act(s_t, p_t, deterministic=True)
+                action_env = squashed.cpu().numpy().reshape(-1) * self.max_action
+                state, reward, done, _ = self.env.step(action_env)
+                ep_obj += np.asarray(reward, dtype=np.float64)
+        return ep_obj
+
+    def _populate_final_buffers(self) -> None:
+        """Set final_ep_objs / final_ep_prefs / final_obj_means / final_obj_stds
+        from the most recent eval. These are the npz schema fields the runner
+        will dump (DESIGN-baselines.md §3)."""
+        if not hasattr(self, "_last_eval_objs"):
+            self.final_ep_objs = np.zeros((1, self.N), dtype=np.float64)
+            self.final_ep_prefs = np.full(
+                (1, self.N), 1.0 / self.N, dtype=np.float64
+            )
+            self.final_obj_means = np.zeros(self.N, dtype=np.float64)
+            self.final_obj_stds = np.zeros(self.N, dtype=np.float64)
+            return
+        self.final_ep_objs = self._last_eval_objs
+        self.final_ep_prefs = self._last_eval_prefs
+        self.final_obj_means = self._last_eval_objs.mean(axis=0)
+        self.final_obj_stds = self._last_eval_objs.std(axis=0)
+
+    # ------------------------------------------------------------------
+    # External API
+    # ------------------------------------------------------------------
+    def policy_fn(self, obs: np.ndarray, preference: np.ndarray) -> np.ndarray:
+        s_t = torch.as_tensor(obs, dtype=torch.float32,
+                              device=self.device).unsqueeze(0)
+        p_t = torch.as_tensor(preference, dtype=torch.float32,
+                              device=self.device).unsqueeze(0)
+        with torch.no_grad():
+            squashed, _, _ = self.actor.act(s_t, p_t, deterministic=True)
+        return squashed.cpu().numpy().reshape(-1) * self.max_action

--- a/scripts/smoketest_mo_ppo.py
+++ b/scripts/smoketest_mo_ppo.py
@@ -1,0 +1,112 @@
+"""Smoke test for the MO-PPO baseline (Issue #8 PR-C).
+
+Verifies the baseline trains end-to-end on UAV-SemCom-v0 for a few thousand
+steps, populates trajectory + final-state buffers correctly, and writes a
+schema-valid npz via the runner. Not a research-quality reproduction —
+just enough to catch import-time / shape / NaN bugs before pushing.
+
+Usage:
+    PYTHONPATH=. python scripts/smoketest_mo_ppo.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+
+if not hasattr(np, "bool8"):
+    np.bool8 = np.bool_
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+def main():
+    print("=== MO-PPO direct construction + tiny train ===")
+    import gym
+    import environments  # noqa: F401
+    from baselines import get_baseline, validate_result_npz, write_result_npz, NpzResult
+
+    env = gym.make("UAV-SemCom-v0", num_devices=5, max_episode_steps=200)
+    env.seed(0)
+
+    cls = get_baseline("mo-ppo")
+    print(f"  registry returned: {cls.__name__}")
+
+    method_kwargs = dict(
+        rollout_T=200,         # 1 episode
+        minibatch_size=32,
+        update_epochs=2,
+        eval_episodes_per_pref=1,
+        device="cpu",
+    )
+    bl = cls(env=env, log_dir=tempfile.mkdtemp(), seed=0,
+             method_kwargs=method_kwargs)
+
+    bl.train(num_steps=600, eval_interval=200)
+
+    # Sanity: trajectories populated
+    assert len(bl.eval_steps) >= 2, f"got {len(bl.eval_steps)} eval points"
+    assert len(bl.hv_trajectory) == len(bl.eval_steps)
+    assert bl.final_ep_objs is not None and bl.final_ep_objs.shape[1] == 4
+    assert bl.final_obj_means.shape == (4,)
+    assert np.all(np.isnan(bl.c_violation_rates)), "MO-PPO unconstrained → NaN"
+    print(f"  eval points: {bl.eval_steps}")
+    print(f"  HV trajectory: {[round(h, 1) for h in bl.hv_trajectory]}")
+    print(f"  final_obj_means: {bl.final_obj_means.round(2).tolist()}")
+    print(f"  wallclock: {bl.wallclock_seconds:.2f}s")
+
+    # NaN/Inf check on every buffer.
+    for arr_name in ["hv_trajectory", "ut_trajectory", "sparsity_trajectory",
+                     "final_obj_means", "final_obj_stds"]:
+        arr = np.asarray(getattr(bl, arr_name))
+        assert np.all(np.isfinite(arr)), f"{arr_name} has non-finite: {arr}"
+    print("  OK: all numeric buffers finite")
+
+    # End-to-end via runner
+    print("\n=== runner end-to-end ===")
+    tmpdir = tempfile.mkdtemp(prefix="smoketest_moppo_")
+    try:
+        cmd = [
+            sys.executable,
+            os.path.join(ROOT, "scripts", "run_baseline.py"),
+            "--baseline", "mo-ppo",
+            "--num_uavs", "1", "--num_devices", "5",
+            "--num_steps", "600", "--eval_interval", "200",
+            "--seed", "0",
+            "--results_dir", tmpdir,
+            "--method_kwargs", json.dumps({
+                "rollout_T": 200, "minibatch_size": 32,
+                "update_epochs": 2, "device": "cpu",
+            }),
+        ]
+        env_var = os.environ.copy()
+        env_var["PYTHONPATH"] = ROOT
+        res = subprocess.run(cmd, env=env_var, capture_output=True, text=True)
+        if res.returncode != 0:
+            print("  STDOUT:", res.stdout)
+            print("  STDERR:", res.stderr)
+            raise AssertionError(f"runner exited {res.returncode}")
+        files = [f for f in os.listdir(tmpdir) if f.endswith(".npz")]
+        assert len(files) == 1, f"expected 1 npz, got {files}"
+        path = os.path.join(tmpdir, files[0])
+        data = validate_result_npz(path)
+        print(f"  saved: {files[0]}")
+        print(f"  schema OK ({len(data)} keys present)")
+        cfg = json.loads(str(data["config_dict"]))
+        assert cfg["baseline"] == "mo-ppo"
+        print(f"  config_dict round-trips: baseline={cfg['baseline']}")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    print("\nAll MO-PPO smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Weighted-sum scalarised PPO with preference-conditioned policy + vector critic. The "vanilla MORL" comparison point. No COR, no OADM, no constraint handler.

**Stacked on PR #30** (skeleton). Base branch is the skeleton branch, not main. After PR #30 merges, I'll rebase this onto main.

Refs: Issue #8, PR #29 (design), PR #30 (skeleton).

## Architectural choices
| Component | Detail |
|-----------|--------|
| Actor | \`MLP(state ⊕ pref) → mean, state-independent log_std\`. Tanh squash on sampled action. |
| Critic | \`MLP(state ⊕ pref) → N scalar values\`. Scalarised advantage \`w·A_vec\` drives the policy update; per-objective targets train the critic. |
| Buffer | GAE(λ=0.95) per objective. Clipped surrogate objective (clip=0.2). |
| Update | Minibatch SGD over the rollout for K epochs. |
| Scalarisation | Weighted-sum (DESIGN §7 Q2 default). Tchebycheff deferred. |
| Eval | Every \`eval_interval\` env steps, run all 56 fixed prefs (\`generate_w_batch_test(N=4, step=0.2)\`), compute HV/UT/sparsity exactly like SemMORL protocol. |

## Files
- \`baselines/_morl_eval.py\` — lightweight \`generate_w_batch_test\` + \`evluate_Hv_UT_and_spa\` re-implementations so MO-PPO doesn't pull tensorboard/visdom/rltorch through agent.py.
- \`baselines/mo_ppo.py\` — actor + vector critic + GAE rollout buffer + train loop + 56-pref eval. Populates the npz-schema buffers via the parent \`Baseline\` ABC.
- \`baselines/__init__.py\` — registers \`mo-ppo\` via lazy import.
- \`scripts/smoketest_mo_ppo.py\` — 600-step smoke verifying construction, train, finite numerics, schema-valid npz.

## Smoke test result (local Python 3.10)
\`\`\`
=== MO-PPO direct construction + tiny train ===
  registry returned: MoPPOBaseline
  eval points: [200, 400, 600]
  HV trajectory: [245B, 118B, 164B]  ← early-training noise, expected
  final_obj_means: [523, 205, 842, 753]
  wallclock: 4.58s
  OK: all numeric buffers finite

=== runner end-to-end ===
  saved: mo-ppo_M1_K5_mobnone_chanalytical_pertnone_constrnone_seed0.npz
  schema OK (12 keys present)
  config_dict round-trips: baseline=mo-ppo

All MO-PPO smoke checks passed.
\`\`\`

## Test plan for full reproduction (deferred to long server)
- [ ] M=2 anchor-config 1M-step run with 6 seeds (~5h × 6 = ~30 GPU-h)
- [ ] HV expected to be measurably below SemMORL (no COR/OADM); should match \`Yang et al. 2019\` envelope MORL ballpark
- [ ] Once long-run completes, this PR moves from "draft" to "ready"

## Out of scope
- Tchebycheff scalarisation (deferred ablation)
- PR-D classical baselines (Pareto-PG, Pareto-Q)
- PR-E C-MORL, PR-F PSL-MORL

🤖 Generated with [Claude Code](https://claude.com/claude-code)