### PR TITLE
feat(baselines): C-MORL registration + stub (Issue #8 PR-E, draft)

### DIFF
--- a/baselines/__init__.py
+++ b/baselines/__init__.py
@@ -57,3 +57,5 @@ __all__ = [
 # register itself by importing it here.
 from . import noop  # noqa: F401
 from . import mo_ppo  # noqa: F401  -- registers "mo-ppo"
+from . import pareto_pg  # noqa: F401  -- registers "pareto-pg"
+from . import pareto_q  # noqa: F401  -- registers "pareto-q"

--- a/baselines/__init__.py
+++ b/baselines/__init__.py
@@ -59,3 +59,4 @@ from . import noop  # noqa: F401
 from . import mo_ppo  # noqa: F401  -- registers "mo-ppo"
 from . import pareto_pg  # noqa: F401  -- registers "pareto-pg"
 from . import pareto_q  # noqa: F401  -- registers "pareto-q"
+from . import c_morl  # noqa: F401  -- registers "c-morl" (stub)

--- a/baselines/c_morl.py
+++ b/baselines/c_morl.py
@@ -1,0 +1,100 @@
+"""C-MORL baseline (Issue #8 PR-E, **stub**).
+
+This file establishes the registration entry, the configuration surface, the
+upstream-repo provenance, and the porting checklist so the actual training
+loop can land in a follow-up commit without re-deriving the integration
+contract. ``train()`` raises NotImplementedError until the upstream code is
+vendored and adapted (~3 weeks of work per DESIGN-baselines.md §5 PR-E gate).
+
+The decision to ship the stub now (rather than a full port) is documented in
+DESIGN-baselines.md §5 — PR-E is allocated week 4–7 and runs in parallel with
+PR-F. Having the registration + config plumbing land early lets the runner +
+analysis tooling start being exercised against the C-MORL filename / npz path
+before the heavy port finishes.
+
+Upstream:
+    paper:        Liu et al. 2024 — "C-MORL: Constrained Multi-Objective RL"
+                  arXiv:2410.02236, ICLR 2025.
+    repo:         https://github.com/RuohLiuq/C-MORL
+    pinned commit: 67473b5afbc1be55e2b8c6ae704afc927bf218ee (2025-08-27)
+    license:      not declared at repo root as of 2026-05-02 — see SKETCHES §3.1
+                  for the action item to confirm permitted use before vendoring.
+
+Algorithm summary (Stage 1 + Stage 2):
+    Stage 1 — train one policy per simplex-corner preference (4 corners for our
+              N=4). Use vanilla PPO from the upstream repo.
+    Stage 2 — for each *non-corner* preference in the eval grid, run a
+              constrained PPO that maximises the targeted objective subject to
+              the other three exceeding their Stage-1 levels minus a slack.
+              Lagrangian dual handles the constraints.
+
+Adaptation work (DESIGN-baselines.md §5 PR-E + SKETCHES §3.1):
+    1. Vendor the C-MORL repo at the pinned commit under
+       ``vendor/c_morl/`` with an attribution NOTICE and a deferred-license
+       resolution path. (~0.5 week)
+    2. Write a gym-compatible env adapter that exposes our
+       ``UAVSemComEnv`` / ``MultiUAVSemComEnv`` through the
+       ``gym.Env`` interface that C-MORL expects — its native interface is
+       gym 0.21 four-tuple step(); ours uses the same convention so this is
+       a thin shim. (~0.5 week)
+    3. Adapt the action mapping from MuJoCo control to our
+       (a_x, a_y, p_k, η_k) layout. (~1 week)
+    4. Adapt the reward vector — replace native multi-objective reward with
+       our 4-objective UAV-SemCom rewards. (~1 week)
+    5. Hyperparameter tuning for our environment (preference grid, constraint
+       thresholds, Stage-1 corner selection). (~0.5 week)
+    Decision deadline 2026-09-15: if Stage-2 still degenerate after 1.5 weeks,
+    fall back to "C-MORL-corner" or "C-MORL S1" per pre-mortem §6.1.
+
+Files this stub touches:
+    baselines/c_morl.py          — this file (registration + config + plan)
+    baselines/__init__.py        — adds ``from . import c_morl`` import
+    scripts/smoketest_cmorl_stub.py — confirms registration works without
+                                      depending on the upstream repo
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from .base import Baseline
+from .registry import register_baseline
+
+
+@register_baseline("c-morl")
+class CMORLBaseline(Baseline):
+    """C-MORL baseline — registration + plan stub.
+
+    Constructable for runner-side smoke testing. ``train()`` raises until the
+    full port lands. ``policy_fn`` returns a midpoint action so the runner's
+    final-eval pass cannot crash when invoked.
+    """
+
+    name = "c-morl"
+
+    def __init__(
+        self,
+        env,
+        log_dir: str,
+        seed: int,
+        method_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(env, log_dir, seed, method_kwargs)
+        self.is_constrained = True  # C-MORL enforces constraints natively
+        # Once the port lands, c_violation_rates will be populated from the
+        # final-eval pass on the saved checkpoint.
+
+    def train(self, num_steps: int, eval_interval: int, our_wandb=None) -> None:
+        raise NotImplementedError(
+            "C-MORL training loop is not yet ported. See baselines/c_morl.py "
+            "module docstring for the porting plan and DESIGN-baselines.md §5 "
+            "PR-E for the schedule. Pinned upstream commit: 67473b5."
+        )
+
+    def policy_fn(self, obs: np.ndarray, preference: np.ndarray) -> np.ndarray:
+        # Mid-range action — enough to make the runner's final-eval pass not
+        # crash when the stub is exercised.
+        low = self.env.action_space.low
+        high = self.env.action_space.high
+        return ((low + high) / 2.0).astype(np.float32)

--- a/baselines/pareto_pg.py
+++ b/baselines/pareto_pg.py
@@ -1,0 +1,216 @@
+"""Pareto Policy Gradient baseline (Issue #8 PR-D).
+
+Vanilla REINFORCE-style policy gradient with preference-conditioned policy
+and a vector value baseline. Differs from MO-PPO by *not* clipping the
+surrogate objective and *not* doing GAE — the simplest scalarised PG that
+still trains.
+
+This is the "no fancy machinery" lower bound that reviewers expect: if a
+proposed method only beats Pareto-PG by a small margin, the proposed
+machinery probably isn't doing much. If it dominates Pareto-PG by a large
+margin, the machinery matters.
+
+Algorithm per episode rollout:
+    1. Sample preference w from the simplex.
+    2. Run an episode, collecting (s_t, a_t, r_t_vec) tuples.
+    3. Compute per-objective discounted returns G_t_vec.
+    4. Vector-baseline subtraction: A_t_vec = G_t_vec - V(s_t, w)_vec.
+    5. Scalarise: A_t = w · A_t_vec.
+    6. Policy gradient: ∇ log π(a|s, w) · A_t.
+    7. Critic regression on G_t_vec (per objective).
+
+Default scalarisation: weighted-sum (DESIGN-baselines.md §7 Q2 default).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Optional, Dict, Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from ._morl_eval import evluate_Hv_UT_and_spa, generate_w_batch_test
+from .base import Baseline
+from .registry import register_baseline
+from .mo_ppo import PPOActor, PPOVectorCritic, _sample_pref
+
+
+@register_baseline("pareto-pg")
+class ParetoPGBaseline(Baseline):
+    """REINFORCE-style scalarised PG with preference-conditioned policy."""
+
+    name = "pareto-pg"
+
+    def __init__(self, env, log_dir: str, seed: int,
+                 method_kwargs: Optional[Dict[str, Any]] = None):
+        super().__init__(env, log_dir, seed, method_kwargs)
+        mk = self.method_kwargs
+
+        self.gamma = float(mk.get("gamma", 0.99))
+        self.lr_actor = float(mk.get("lr_actor", 3e-4))
+        self.lr_critic = float(mk.get("lr_critic", 1e-3))
+        self.entropy_coef = float(mk.get("entropy_coef", 0.0))
+        self.episodes_per_update = int(mk.get("episodes_per_update", 4))
+        self.hidden = tuple(mk.get("hidden", (64, 64)))
+        self.device = torch.device(mk.get("device", "cpu"))
+
+        self.state_dim = env.observation_space.shape[0]
+        self.action_dim = env.action_space.shape[0]
+        self.N = int(getattr(env, "reward_num", 4))
+        self.max_action = env.action_space.high
+
+        torch.manual_seed(self.seed)
+        np.random.seed(self.seed)
+        self.rng = np.random.RandomState(self.seed)
+
+        self.actor = PPOActor(self.state_dim, self.N, self.action_dim,
+                              hidden=self.hidden).to(self.device)
+        self.critic = PPOVectorCritic(self.state_dim, self.N, self.N,
+                                      hidden=self.hidden).to(self.device)
+        self.opt_actor = torch.optim.Adam(self.actor.parameters(), lr=self.lr_actor)
+        self.opt_critic = torch.optim.Adam(self.critic.parameters(), lr=self.lr_critic)
+
+        step_map = {3: 0.05, 4: 0.2, 5: 0.25}
+        self.eval_prefs = generate_w_batch_test(
+            self.N, step_size=step_map.get(self.N, 0.2)
+        )
+
+    # ------------------------------------------------------------------
+    def train(self, num_steps: int, eval_interval: int, our_wandb=None) -> None:
+        env = self.env
+        env.seed(self.seed)
+        steps = 0
+        t0 = time.time()
+        next_eval = eval_interval
+
+        while steps < num_steps:
+            # Collect a batch of episodes_per_update episodes at a sampled
+            # preference each, then a single PG update.
+            batch_states, batch_prefs, batch_raw_acts = [], [], []
+            batch_returns_vec = []
+            for _ in range(self.episodes_per_update):
+                pref = _sample_pref(self.rng, self.N)
+                ep_states, ep_raw_acts, ep_rewards = [], [], []
+                state = env.reset()
+                done = False
+                while not done:
+                    s_t = torch.as_tensor(state, dtype=torch.float32,
+                                          device=self.device).unsqueeze(0)
+                    p_t = torch.as_tensor(pref, dtype=torch.float32,
+                                          device=self.device).unsqueeze(0)
+                    with torch.no_grad():
+                        squashed, _, raw = self.actor.act(s_t, p_t)
+                    a_squashed = squashed.cpu().numpy().reshape(-1)
+                    a_raw = raw.cpu().numpy().reshape(-1)
+                    next_state, reward, done, _ = env.step(a_squashed * self.max_action)
+                    ep_states.append(state)
+                    ep_raw_acts.append(a_raw)
+                    ep_rewards.append(np.asarray(reward, dtype=np.float32))
+                    state = next_state
+                    steps += 1
+                    if steps >= num_steps:
+                        done = True
+                    if steps >= next_eval:
+                        self._evaluate(steps)
+                        next_eval += eval_interval
+                # Per-objective discounted returns.
+                T = len(ep_rewards)
+                G = np.zeros((T, self.N), dtype=np.float32)
+                running = np.zeros(self.N, dtype=np.float32)
+                for t in reversed(range(T)):
+                    running = ep_rewards[t] + self.gamma * running
+                    G[t] = running
+                batch_states.append(np.asarray(ep_states, dtype=np.float32))
+                batch_prefs.append(np.tile(pref, (T, 1)))
+                batch_raw_acts.append(np.asarray(ep_raw_acts, dtype=np.float32))
+                batch_returns_vec.append(G)
+                if steps >= num_steps:
+                    break
+            self._update(batch_states, batch_prefs, batch_raw_acts, batch_returns_vec)
+
+        if not self.eval_steps or self.eval_steps[-1] < num_steps:
+            self._evaluate(num_steps)
+        self._populate_final_buffers()
+        self.wallclock_seconds = time.time() - t0
+
+    def _update(self, batch_states, batch_prefs, batch_raw_acts, batch_returns_vec) -> None:
+        states = torch.as_tensor(np.concatenate(batch_states), device=self.device)
+        prefs = torch.as_tensor(np.concatenate(batch_prefs), device=self.device)
+        raw_acts = torch.as_tensor(np.concatenate(batch_raw_acts), device=self.device)
+        returns_vec = torch.as_tensor(np.concatenate(batch_returns_vec), device=self.device)
+
+        # Critic update on per-objective returns.
+        values = self.critic(states, prefs)
+        critic_loss = F.mse_loss(values, returns_vec)
+        self.opt_critic.zero_grad()
+        critic_loss.backward()
+        self.opt_critic.step()
+
+        # Actor update with vector baseline.
+        with torch.no_grad():
+            baselines = self.critic(states, prefs)
+        adv_vec = returns_vec - baselines
+        adv_scalar = (adv_vec * prefs).sum(-1)
+        adv_scalar = (adv_scalar - adv_scalar.mean()) / (adv_scalar.std() + 1e-8)
+        logp, entropy = self.actor.evaluate(states, prefs, raw_acts)
+        actor_loss = -(logp * adv_scalar).mean() - self.entropy_coef * entropy.mean()
+        self.opt_actor.zero_grad()
+        actor_loss.backward()
+        self.opt_actor.step()
+
+    # ------------------------------------------------------------------
+    def _evaluate(self, step: int) -> None:
+        objs = []
+        for pref in self.eval_prefs:
+            objs.append(self._eval_episode(pref))
+        objs = np.asarray(objs, dtype=np.float64)
+        hv, sparsity, ut = evluate_Hv_UT_and_spa(self.N, objs, self.eval_prefs)
+        self._record_eval(step=step, hv=hv, ut=ut, sparsity=sparsity)
+        self._last_eval_objs = objs
+        self._last_eval_prefs = np.asarray(self.eval_prefs, dtype=np.float64)
+
+    def _eval_episode(self, preference: np.ndarray) -> np.ndarray:
+        ep_obj = np.zeros(self.N, dtype=np.float64)
+        self.env.seed(self.seed + 1_000_000 + int(preference[0] * 1e6))
+        state = self.env.reset()
+        done = False
+        with torch.no_grad():
+            while not done:
+                s_t = torch.as_tensor(state, dtype=torch.float32,
+                                      device=self.device).unsqueeze(0)
+                p_t = torch.as_tensor(preference, dtype=torch.float32,
+                                      device=self.device).unsqueeze(0)
+                squashed, _, _ = self.actor.act(s_t, p_t, deterministic=True)
+                action_env = squashed.cpu().numpy().reshape(-1) * self.max_action
+                state, reward, done, _ = self.env.step(action_env)
+                ep_obj += np.asarray(reward, dtype=np.float64)
+        return ep_obj
+
+    def _populate_final_buffers(self) -> None:
+        if not hasattr(self, "_last_eval_objs"):
+            self.final_ep_objs = np.zeros((1, self.N), dtype=np.float64)
+            self.final_ep_prefs = np.full((1, self.N), 1.0 / self.N, dtype=np.float64)
+            self.final_obj_means = np.zeros(self.N, dtype=np.float64)
+            self.final_obj_stds = np.zeros(self.N, dtype=np.float64)
+            return
+        self.final_ep_objs = self._last_eval_objs
+        self.final_ep_prefs = self._last_eval_prefs
+        self.final_obj_means = self._last_eval_objs.mean(axis=0)
+        self.final_obj_stds = self._last_eval_objs.std(axis=0)
+
+    def policy_fn(self, obs: np.ndarray, preference: np.ndarray) -> np.ndarray:
+        s_t = torch.as_tensor(obs, dtype=torch.float32,
+                              device=self.device).unsqueeze(0)
+        p_t = torch.as_tensor(preference, dtype=torch.float32,
+                              device=self.device).unsqueeze(0)
+        with torch.no_grad():
+            squashed, _, _ = self.actor.act(s_t, p_t, deterministic=True)
+        return squashed.cpu().numpy().reshape(-1) * self.max_action

--- a/baselines/pareto_q.py
+++ b/baselines/pareto_q.py
@@ -1,0 +1,231 @@
+"""Pareto Q-Learning baseline (Issue #8 PR-D, tabular variant).
+
+Per DESIGN-baselines.md §7 Q1, the default scope here is **tabular with state
+aggregation** — explicitly weaker than the function-approximation version,
+chosen for porting speed (1 week budget). The journal experiments will
+document this limitation.
+
+Algorithmic simplification (also documented in §7 Q1): we store *one*
+vector Q(s_macro, a_macro) per macro-cell rather than the full set of
+non-dominated vectors. Action selection scalarises with the current
+preference. This is the MO-Q variant of Pareto Q-Learning and remains the
+"no-deep-RL lower bound" data point we want.
+
+State aggregation (UAVSemComEnv only — Multi-UAV K=5 single-UAV path):
+    - UAV position: 5×5 grid → 25 cells.
+    - Mean AoSI bucket: low (≤2), medium (2–5), high (>5) → 3 cells.
+    - Total macro-states: 75.
+
+Action aggregation:
+    - 9 macro-actions: 8 compass directions × fixed move speed, plus "stop".
+    - Power and compression are fixed per macro-action (mid-range values).
+    - Maps onto the env's continuous (a_x, a_y, p_k, η_k) action layout.
+
+Limitations (will be cited verbatim in the paper):
+    - Single-UAV only (M=1). Multi-UAV joint state would explode the macro
+      table; requires a different aggregation scheme out of scope for #8.
+    - Single Q-vector per cell (no Pareto set). FA version with
+      non-dominated sets is deferred.
+
+This is enough machinery to put a useful "below the line" data point on
+the journal Pareto-front plot.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Optional, Dict, Any
+
+import numpy as np
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from ._morl_eval import evluate_Hv_UT_and_spa, generate_w_batch_test
+from .base import Baseline
+from .registry import register_baseline
+
+
+# Compass macro-actions: (dx, dy) at unit speed plus a stop.
+MACRO_DIRS = np.array([
+    (1.0, 0.0),    # E
+    (-1.0, 0.0),   # W
+    (0.0, 1.0),    # N
+    (0.0, -1.0),   # S
+    (0.7071, 0.7071),    # NE
+    (-0.7071, 0.7071),   # NW
+    (0.7071, -0.7071),   # SE
+    (-0.7071, -0.7071),  # SW
+    (0.0, 0.0),    # stop
+], dtype=np.float32)
+N_MACRO_ACTIONS = len(MACRO_DIRS)
+
+
+def _state_to_cell(env, obs: np.ndarray) -> int:
+    """Aggregate continuous state to a macro-cell id in [0, 75)."""
+    # The first two dims of obs are normalised UAV pos in [0, 1].
+    # AoSI starts at offset depending on K; pull from env directly.
+    pos_x, pos_y = float(obs[0]), float(obs[1])
+    # 5x5 grid
+    bx = int(np.clip(pos_x * 5, 0, 4))
+    by = int(np.clip(pos_y * 5, 0, 4))
+    aosi_bucket = 0
+    aosi = getattr(env, "aosi", None)
+    if aosi is not None:
+        m = float(np.mean(aosi))
+        if m > 5.0:
+            aosi_bucket = 2
+        elif m > 2.0:
+            aosi_bucket = 1
+    return bx * 15 + by * 3 + aosi_bucket
+
+
+def _macro_to_env_action(env, macro_idx: int) -> np.ndarray:
+    """Map macro-action id to the continuous action vector the env expects.
+
+    Layout (single-UAV): [a_x, a_y, p_1..K, η_1..K]. Macro-action only sets
+    direction; power and compression are fixed at mid-range.
+    """
+    K = env.num_devices
+    action = np.zeros(2 + 2 * K, dtype=np.float32)
+    action[0:2] = MACRO_DIRS[macro_idx]
+    # Fixed mid-range power (0.5 of [-1,1] mapping to half max_action).
+    action[2:2 + K] = 0.5
+    action[2 + K:2 + 2 * K] = 0.0  # compression at mid (sigmoid maps 0 → 0.5)
+    return action
+
+
+@register_baseline("pareto-q")
+class ParetoQBaseline(Baseline):
+    """Tabular MO-Q with single Q-vector per (macro-state, macro-action)."""
+
+    name = "pareto-q"
+
+    def __init__(self, env, log_dir: str, seed: int,
+                 method_kwargs: Optional[Dict[str, Any]] = None):
+        super().__init__(env, log_dir, seed, method_kwargs)
+        if getattr(env, "num_uavs", 1) != 1:
+            raise NotImplementedError(
+                "Pareto-Q baseline supports M=1 only; multi-UAV aggregation "
+                "is out of scope (DESIGN-baselines.md §7 Q1)."
+            )
+        mk = self.method_kwargs
+
+        self.gamma = float(mk.get("gamma", 0.99))
+        self.alpha = float(mk.get("alpha", 0.1))  # learning rate
+        self.eps_start = float(mk.get("eps_start", 1.0))
+        self.eps_end = float(mk.get("eps_end", 0.05))
+        self.eps_decay_steps = int(mk.get("eps_decay_steps", 200_000))
+        self.N = int(getattr(env, "reward_num", 4))
+
+        self.n_states = 75  # 5x5 pos × 3 aosi buckets
+        self.n_actions = N_MACRO_ACTIONS
+        self.Q = np.zeros((self.n_states, self.n_actions, self.N), dtype=np.float64)
+
+        self.rng = np.random.RandomState(self.seed)
+        step_map = {3: 0.05, 4: 0.2, 5: 0.25}
+        self.eval_prefs = generate_w_batch_test(
+            self.N, step_size=step_map.get(self.N, 0.2)
+        )
+
+    # ------------------------------------------------------------------
+    def _epsilon(self, step: int) -> float:
+        frac = min(1.0, step / max(self.eps_decay_steps, 1))
+        return self.eps_start + frac * (self.eps_end - self.eps_start)
+
+    def _greedy_action(self, cell: int, pref: np.ndarray) -> int:
+        scalarised = (self.Q[cell] * pref).sum(-1)  # (n_actions,)
+        return int(np.argmax(scalarised))
+
+    def _sample_pref(self) -> np.ndarray:
+        p = self.rng.rand(self.N).astype(np.float32)
+        p /= p.sum()
+        return p
+
+    def train(self, num_steps: int, eval_interval: int, our_wandb=None) -> None:
+        env = self.env
+        env.seed(self.seed)
+        steps = 0
+        t0 = time.time()
+        next_eval = eval_interval
+        cur_pref = self._sample_pref()
+        state = env.reset()
+        cell = _state_to_cell(env, state)
+
+        while steps < num_steps:
+            if self.rng.rand() < self._epsilon(steps):
+                a_macro = int(self.rng.randint(self.n_actions))
+            else:
+                a_macro = self._greedy_action(cell, cur_pref)
+            env_action = _macro_to_env_action(env, a_macro)
+            next_state, reward, done, _ = env.step(env_action)
+            next_cell = _state_to_cell(env, next_state)
+
+            # Vector Bellman backup with scalarised greedy next action.
+            r = np.asarray(reward, dtype=np.float64)
+            if done:
+                target = r
+            else:
+                a_next = self._greedy_action(next_cell, cur_pref)
+                target = r + self.gamma * self.Q[next_cell, a_next]
+            self.Q[cell, a_macro] += self.alpha * (target - self.Q[cell, a_macro])
+
+            state = next_state
+            cell = next_cell
+            steps += 1
+            if done:
+                state = env.reset()
+                cell = _state_to_cell(env, state)
+                cur_pref = self._sample_pref()
+            if steps >= next_eval:
+                self._evaluate(steps)
+                next_eval += eval_interval
+
+        if not self.eval_steps or self.eval_steps[-1] < num_steps:
+            self._evaluate(num_steps)
+        self._populate_final_buffers()
+        self.wallclock_seconds = time.time() - t0
+
+    # ------------------------------------------------------------------
+    def _evaluate(self, step: int) -> None:
+        objs = []
+        for pref in self.eval_prefs:
+            objs.append(self._eval_episode(pref))
+        objs = np.asarray(objs, dtype=np.float64)
+        hv, sparsity, ut = evluate_Hv_UT_and_spa(self.N, objs, self.eval_prefs)
+        self._record_eval(step=step, hv=hv, ut=ut, sparsity=sparsity)
+        self._last_eval_objs = objs
+        self._last_eval_prefs = np.asarray(self.eval_prefs, dtype=np.float64)
+
+    def _eval_episode(self, preference: np.ndarray) -> np.ndarray:
+        ep_obj = np.zeros(self.N, dtype=np.float64)
+        self.env.seed(self.seed + 1_000_000 + int(preference[0] * 1e6))
+        state = self.env.reset()
+        cell = _state_to_cell(self.env, state)
+        done = False
+        while not done:
+            a_macro = self._greedy_action(cell, preference)
+            env_action = _macro_to_env_action(self.env, a_macro)
+            state, reward, done, _ = self.env.step(env_action)
+            cell = _state_to_cell(self.env, state)
+            ep_obj += np.asarray(reward, dtype=np.float64)
+        return ep_obj
+
+    def _populate_final_buffers(self) -> None:
+        if not hasattr(self, "_last_eval_objs"):
+            self.final_ep_objs = np.zeros((1, self.N), dtype=np.float64)
+            self.final_ep_prefs = np.full((1, self.N), 1.0 / self.N, dtype=np.float64)
+            self.final_obj_means = np.zeros(self.N, dtype=np.float64)
+            self.final_obj_stds = np.zeros(self.N, dtype=np.float64)
+            return
+        self.final_ep_objs = self._last_eval_objs
+        self.final_ep_prefs = self._last_eval_prefs
+        self.final_obj_means = self._last_eval_objs.mean(axis=0)
+        self.final_obj_stds = self._last_eval_objs.std(axis=0)
+
+    def policy_fn(self, obs: np.ndarray, preference: np.ndarray) -> np.ndarray:
+        cell = _state_to_cell(self.env, obs)
+        a_macro = self._greedy_action(cell, preference)
+        return _macro_to_env_action(self.env, a_macro)

--- a/scripts/smoketest_classical.py
+++ b/scripts/smoketest_classical.py
@@ -1,0 +1,109 @@
+"""Smoke test for the classical baselines (Issue #8 PR-D).
+
+Two baselines registered: ``pareto-pg`` and ``pareto-q``. This script
+constructs each, trains for a few hundred env steps, asserts the
+trajectory + final-state buffers populate correctly, and runs them
+through the runner so the produced npz validates against the schema.
+
+Usage:
+    PYTHONPATH=. python scripts/smoketest_classical.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+
+if not hasattr(np, "bool8"):
+    np.bool8 = np.bool_
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+def _direct_smoke(name: str, kwargs: dict, num_steps: int, eval_interval: int):
+    print(f"=== direct smoke: {name} ===")
+    import gym
+    import environments  # noqa: F401
+    from baselines import get_baseline
+
+    env = gym.make("UAV-SemCom-v0", num_devices=5, max_episode_steps=200)
+    env.seed(0)
+    cls = get_baseline(name)
+    print(f"  registry returned: {cls.__name__}")
+    bl = cls(env=env, log_dir=tempfile.mkdtemp(), seed=0,
+             method_kwargs=kwargs)
+    bl.train(num_steps=num_steps, eval_interval=eval_interval)
+    assert len(bl.eval_steps) >= 1, f"no eval points for {name}"
+    assert bl.final_ep_objs is not None and bl.final_ep_objs.shape[1] == 4
+    assert np.all(np.isnan(bl.c_violation_rates)), f"{name} unconstrained → NaN"
+    for arr_name in ["hv_trajectory", "ut_trajectory", "sparsity_trajectory",
+                     "final_obj_means", "final_obj_stds"]:
+        arr = np.asarray(getattr(bl, arr_name))
+        assert np.all(np.isfinite(arr)), f"{name}.{arr_name} non-finite: {arr}"
+    print(f"  eval points: {bl.eval_steps}")
+    print(f"  HV trajectory: {[round(h, 1) for h in bl.hv_trajectory]}")
+    print(f"  final_obj_means: {bl.final_obj_means.round(2).tolist()}")
+    print(f"  wallclock: {bl.wallclock_seconds:.2f}s")
+    print(f"  OK: all numeric buffers finite")
+
+
+def _runner_smoke(name: str, kwargs: dict, num_steps: int, eval_interval: int):
+    print(f"\n=== runner smoke: {name} ===")
+    from baselines import validate_result_npz
+    tmpdir = tempfile.mkdtemp(prefix=f"smoketest_{name.replace('-', '_')}_")
+    try:
+        cmd = [
+            sys.executable,
+            os.path.join(ROOT, "scripts", "run_baseline.py"),
+            "--baseline", name,
+            "--num_uavs", "1", "--num_devices", "5",
+            "--num_steps", str(num_steps),
+            "--eval_interval", str(eval_interval),
+            "--seed", "0",
+            "--results_dir", tmpdir,
+            "--method_kwargs", json.dumps(kwargs),
+        ]
+        env_var = os.environ.copy()
+        env_var["PYTHONPATH"] = ROOT
+        res = subprocess.run(cmd, env=env_var, capture_output=True, text=True)
+        if res.returncode != 0:
+            print("  STDOUT:", res.stdout)
+            print("  STDERR:", res.stderr)
+            raise AssertionError(f"runner exited {res.returncode}")
+        files = [f for f in os.listdir(tmpdir) if f.endswith(".npz")]
+        assert len(files) == 1, f"expected 1 npz, got {files}"
+        path = os.path.join(tmpdir, files[0])
+        data = validate_result_npz(path)
+        print(f"  saved: {files[0]}")
+        print(f"  schema OK ({len(data)} keys)")
+        cfg = json.loads(str(data["config_dict"]))
+        assert cfg["baseline"] == name
+        print(f"  config_dict round-trips: baseline={cfg['baseline']}")
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def main():
+    pg_kwargs = dict(
+        episodes_per_update=2, hidden=(32, 32), device="cpu",
+    )
+    q_kwargs = dict(
+        eps_decay_steps=500,
+    )
+
+    _direct_smoke("pareto-pg", pg_kwargs, num_steps=400, eval_interval=200)
+    _direct_smoke("pareto-q", q_kwargs, num_steps=400, eval_interval=200)
+    _runner_smoke("pareto-pg", pg_kwargs, num_steps=400, eval_interval=200)
+    _runner_smoke("pareto-q", q_kwargs, num_steps=400, eval_interval=200)
+    print("\nAll classical-baseline smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoketest_cmorl_stub.py
+++ b/scripts/smoketest_cmorl_stub.py
@@ -1,0 +1,72 @@
+"""Smoke test for the C-MORL stub (Issue #8 PR-E).
+
+Confirms the stub registers cleanly, is constructable through the runner,
+and that ``train()`` raises NotImplementedError with a useful message
+pointing the reader at the porting plan. Intentionally narrow — the full
+training loop is not exercised because it doesn't exist yet.
+
+Usage:
+    PYTHONPATH=. python scripts/smoketest_cmorl_stub.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import numpy as np
+
+if not hasattr(np, "bool8"):
+    np.bool8 = np.bool_
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+def main():
+    print("=== step 1: registration ===")
+    from baselines import get_baseline, list_baselines
+    names = list_baselines()
+    assert "c-morl" in names, f"c-morl missing from registry: {names}"
+    cls = get_baseline("c-morl")
+    print(f"  registry returned: {cls.__name__}")
+
+    print("\n=== step 2: construction ===")
+    import gym
+    import environments  # noqa: F401
+    env = gym.make("UAV-SemCom-v0", num_devices=5, max_episode_steps=200)
+    env.seed(0)
+    bl = cls(env=env, log_dir=tempfile.mkdtemp(), seed=0, method_kwargs={})
+    print(f"  constructed: {bl.name}")
+    assert bl.is_constrained, "C-MORL should advertise itself as constrained"
+    print(f"  is_constrained: {bl.is_constrained}")
+
+    print("\n=== step 3: train() raises NotImplementedError with the right pointer ===")
+    try:
+        bl.train(num_steps=10, eval_interval=5)
+        raise AssertionError("expected NotImplementedError")
+    except NotImplementedError as e:
+        msg = str(e)
+        assert "porting plan" in msg or "DESIGN-baselines.md" in msg or "67473b5" in msg, (
+            f"NotImplementedError message should reference porting plan: {msg!r}"
+        )
+        print(f"  OK: train() raised with pointer to porting plan")
+        print(f"  message: {msg}")
+
+    print("\n=== step 4: policy_fn returns valid action shape ===")
+    obs = env.reset()
+    pref = np.array([0.25, 0.25, 0.25, 0.25], dtype=np.float32)
+    action = bl.policy_fn(obs, pref)
+    assert action.shape == env.action_space.shape, (
+        f"policy_fn shape: {action.shape} vs {env.action_space.shape}"
+    )
+    assert np.all(action >= env.action_space.low - 1e-6), "action below low bound"
+    assert np.all(action <= env.action_space.high + 1e-6), "action above high bound"
+    print(f"  OK: policy_fn returns shape={action.shape}, in bounds")
+
+    print("\nAll C-MORL stub smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
**Stub** — registration + config surface + porting checklist. Full C-MORL training loop is a 3.5-week effort (DESIGN §5 PR-E) and lands in follow-up commits.

**Stacked on PR #32 (classical baselines).**

Refs: Issue #8, PR #29 §5 PR-E, SKETCHES.md §3.1 (per-baseline porting plan with repo URL + pinned commit).

## Why land the stub now
- Same pattern as Issue #6 PR-A (design first, implementation follows in chunks).
- Lets the runner + analysis tooling exercise the C-MORL filename / npz path well before the heavy port lands.
- Pins upstream provenance (commit, license-status, action item) into the codebase so multiple PR-E iterations don't re-derive it.

## What works in this stub
- Registers \`c-morl\` in the baselines registry.
- Constructable via \`get_baseline("c-morl")(env, log_dir, seed)\`.
- \`is_constrained = True\` advertised on the instance.
- \`policy_fn\` returns a midpoint action so the runner's final-eval pass cannot crash when invoked.
- \`train()\` raises \`NotImplementedError\` with a message pointing at the porting plan.

## Upstream provenance (in \`c_morl.py\` docstring)
- **paper**: arXiv:2410.02236, ICLR 2025
- **repo**: https://github.com/RuohLiuq/C-MORL
- **pinned commit**: \`67473b5afbc1be55e2b8c6ae704afc927bf218ee\` (2025-08-27)
- **license**: not declared at repo root as of 2026-05-02 — action item to confirm permitted use before vendoring (SKETCHES §3.1)

## Adaptation work remaining (~3 weeks)
1. Vendor upstream code under \`vendor/c_morl/\` with NOTICE
2. gym-compat env adapter for our \`UAVSemComEnv\` / \`MultiUAVSemComEnv\`
3. Action mapping (MuJoCo control → \`(a_x, a_y, p_k, η_k)\`)
4. Reward vector adaptation
5. Hyperparameter tuning (Stage-1 corner selection, Stage-2 constraint thresholds)

**Decision deadline 2026-09-15**: fall back to "C-MORL-corner" or "C-MORL S1" per DESIGN §6.1 if Stage-2 stays degenerate on continuous prefs.

## Smoke test (local Python 3.10)
\`\`\`
=== step 1: registration ===                OK (c-morl in registry)
=== step 2: construction ===                OK (is_constrained = True)
=== step 3: train() raises ===              OK (message references porting plan + commit)
=== step 4: policy_fn returns (12,) in bounds ===
All C-MORL stub smoke checks passed.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)