### PR TITLE
fix(env): multiplier rescale + soft floor (ADR-0010, supersedes 0009)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -310,3 +310,83 @@ Why `−4.0` specifically:
 See `environments/uav_semcom_multi_env.py:337-356` for the change and the M=4 diagnostic table above for the failure data that motivated the fix.
 
 ---
+
+## ADR-0010 — Multiplier rescale `* 4.0 / num_uavs` + soft floor (supersedes ADR-0009)
+
+**Date**: 2026-05-08
+**Status**: Accepted (supersedes ADR-0009 partially — soft floor remains; magnitude rescale added)
+
+### Context
+The M=4 pilot under ADR-0009 (soft floor at -4.0, no rescale) was killed at step 360K after observing classic policy collapse:
+
+| step | HV | mean r3 |
+|------|-------|---------|
+| 100K | 127 GB | -321 |
+| 180K | **204 GB** (peak) | -168 |
+| 240K | 157 GB | -470 |
+| 280K | 38 GB | -739 |
+| 300K | 0.4 GB | -692 |
+| 340K | 0 GB | -781 |
+| 360K | 0 GB | -757 |
+
+The agent climbed to a usable Pareto front by 180K, then progressively lost it as SAC's entropy bonus drove exploration into a degenerate "uncoordinated swarm" attractor. ADR-0009's soft floor at -4.0 capped the *worst-case* reward but did not reduce the *gradient strength* — the M=4 raw multiplier `* 4.0` produces per-step penalties up to -11.5 (or -4.0 after floor), still ~2× the magnitude of any other reward component, which is enough to push the policy gradient off-balance once entropy decays.
+
+Diagnosis reframed: the issue is not just the magnitude of the lower bound; it's the **gradient strength of the energy term relative to the other three rewards**. ADR-0009 addressed magnitude; ADR-0010 addresses gradient strength.
+
+### Decision
+Combine two fixes:
+
+1. **Multiplier rescale `* 4.0 / num_uavs`**: keeps the per-step reward range comparable to single-UAV across all M.
+2. **Keep the soft floor at -4.0** (ADR-0009): safety cap in case future env extensions or `coll_pen` push r_energy outside the rescaled range.
+
+```python
+r_energy = (
+    (self.max_energy - e_total - coll_pen)
+    / max(self.max_energy - self.min_energy, 1e-6) * (4.0 / self.num_uavs) + 0.5
+)
+r_energy = max(-4.0, r_energy)
+```
+
+Per-step ranges and coordination-gradient strength:
+
+| M | range | range size | coord. gradient (full vs coord) |
+|---|-------|-----------|-----|
+| 1 | [0.5, 4.5] | 4.0 | N/A (single-UAV class untouched) |
+| 2 | [-1.5, 2.5] | 4.0 | 2.0 per step |
+| 3 | [-2.2, 1.8] | 4.0 | 2.7 per step |
+| 4 | [-2.5, 1.5] | 4.0 | 3.0 per step |
+| 5 | [-2.7, 1.3] | 4.0 | 3.2 per step |
+
+vs ADR-0008/0009 strength at M=4: 12.0 per step (4× too strong). vs buggy ADR-0006: 0 per step (M cancelled). ADR-0010 is the goldilocks middle.
+
+The soft floor at -4.0 is now dead code in expected operating regimes (M=4 worst case is -2.5, M=5 is -2.7). Kept as a safety net for future env extensions (e.g., `coll_pen` could push r_energy below -3.0 when many UAVs collide).
+
+### Alternatives Considered (all from ADR-0009 retrospective)
+- **A. Lower the soft floor below -4.0**: would not fix the underlying gradient-strength imbalance.
+- **C. Make ADR-0010 conditional (only rescale when M ≥ 3)**: keeps M=2 bit-identical to ADR-0009 but introduces a discontinuity at M=3. Rejected for cleanliness.
+- **D. 5M-step training under ADR-0009**: doesn't fix the attractor; expensive.
+- **E. Curriculum from M=2**: still a possibility if ADR-0010 is also insufficient; defer.
+
+### Consequences
+- **M=2 fix-floor checkpoint (`pilot-M2-fixfloor-seed1`) is no longer bit-identical** to ADR-0010 — the multiplier is now 2.0 instead of 4.0 for M=2. The old M=2 checkpoint becomes the "ADR-0009 / ADR-0008 reference" data point in the reward-design ablation.
+- **Re-run M=2 under ADR-0010** with `--exp_name pilot-M2-rescaled-seed1`. Expect HV similar to the ~442B fix-floor result; possibly higher because the gradient is now better-balanced with other rewards.
+- **Re-run M=4 under ADR-0010** with `--exp_name pilot-M4-rescaled-seed1`. Expect stable HV ≥ 100B at the final eval.
+- **M=4 ADR-0009 360K checkpoint preserved** (`pilot-M4-softfloor-seed1/checkpoints/policy_3.pkl`) as the ablation data point #5.
+- The reward-design ablation in the paper now spans **five** points:
+  1. buggy-original (× M, floor 0.5) — M-cancellation
+  2. ADR-0006 only (no × M, floor 0.5) — dead gradient
+  3. ADR-0008 only (no × M, no floor) — divergent at M ≥ 4
+  4. ADR-0009 (no × M, floor at -4) — late-training collapse at M=4
+  5. ADR-0010 (rescaled multiplier + floor) — current; expect stable across M
+- Theorem 1's `‖r‖_∞ ≤ r_max(M)` bound becomes a uniform `4.5` across all M ≥ 1 (since rescale keeps range size = 4 and floor caps lower at -4.0 < unfilled bound). Theorem analysis simplifies to single-UAV form. Update `paper/theorem1.tex` once PR #28 lands so the bound matches.
+
+### Risk and gating
+This is the second M=4 retrain attempt. If ADR-0010 also fails to produce stable HV at M=4, escalate to:
+- **F. Curriculum**: warm-start M=4 from M=2 checkpoint (architecture work)
+- **G. Multi-fidelity reward design**: separate r3 into r3a (per-UAV efficiency) + r3b (fleet-level cost) to give the agent two scalar signals instead of one.
+
+But first: run the experiment and look at the data.
+
+See `environments/uav_semcom_multi_env.py:337-378` for the change.
+
+---

--- a/environments/uav_semcom_multi_env.py
+++ b/environments/uav_semcom_multi_env.py
@@ -334,24 +334,38 @@ class MultiUAVSemComEnv(gym.Env):
 
         r_fidelity = weighted_avg_fid * 4.0 + 0.5
         r_freshness = 4.0 * np.exp(-mean_aosi / 4.0) + 0.5
-        # Multi-UAV r_energy uses a soft floor at -4.0 (ADR-0009).
-        # The unfloored form (ADR-0008) restored the energy gradient that
-        # ADR-0006 had silently destroyed, but the resulting reward range
-        # `[0.5 − 4(M−1), 4.5]` is too wide for M ≥ 4: the M=4 1M-step pilot
-        # produced HV = 0 at the final eval, AoSI 27× the M=1 baseline, and
-        # energy 9× the M=1 baseline — the agent converged on an "all UAVs
-        # at full power" policy because the per-step penalty for excess
-        # energy can swing to −11.5 vs other rewards at most 4.5, so a few
-        # bad slots dominate the gradient.
-        # Floor at −4.0: bounds magnitude to ~the same order as the upper
-        # range (4.5) so a single bad slot cannot drown out the other
-        # objectives, while preserving a 4.5 → −4.0 gradient range — wider
-        # than single-UAV [0.5, 4.5] but bounded. M=2's natural lower bound
-        # is −3.5, so M=2 behaviour is bit-identical to ADR-0008. Only
-        # M ≥ 3 sees the new floor fire.
+        # Multi-UAV r_energy uses a multiplier rescaled by num_uavs plus a
+        # safety soft floor at -4.0 (ADR-0010). Combination of two fixes:
+        #
+        # 1. Multiplier rescale `* 4.0 / num_uavs`: keeps the per-step
+        #    reward magnitude comparable to the single-UAV case across all
+        #    M. Per-step ranges are now:
+        #        M=1: [0.5, 4.5]   bit-identical to conference single-UAV
+        #        M=2: [-1.5, 2.5]
+        #        M=4: [-2.5, 1.5]
+        #        M=5: [-2.7, 1.3]
+        #    The gradient toward coordination is preserved (M=4 difference
+        #    between fully-coordinated and fully-wasteful policies is 3.0
+        #    per step, vs the buggy ADR-0006 form's 0). It is weaker than
+        #    ADR-0008 (which was 12.0 per step at M=4) — that strength
+        #    turned out to overpower the other three reward components and
+        #    drive policy collapse (M=4 ADR-0008 pilot final HV=0).
+        #
+        # 2. Soft floor at -4.0: safety cap. Under the rescale alone the
+        #    M=4 worst case is -2.5 and M=5 is -2.7, so the floor is dead
+        #    code in expected operating regimes — it only kicks in if a
+        #    coll_pen or future env extension drives r_energy abnormally
+        #    negative. Preserved from ADR-0009 to keep the bound visible
+        #    and to defend against future reward additions.
+        #
+        # ADR-0009's floor-only fix proved insufficient: the M=4 pilot
+        # under that form ran HV up to 204B at 180K but then collapsed
+        # back to 0 by 360K — agent slipped into a degenerate attractor
+        # the floor could not prevent because the unrescaled magnitude
+        # still overpowered the other objectives.
         r_energy = (
             (self.max_energy - e_total - coll_pen)
-            / max(self.max_energy - self.min_energy, 1e-6) * 4.0 + 0.5
+            / max(self.max_energy - self.min_energy, 1e-6) * (4.0 / self.num_uavs) + 0.5
         )
         r_energy = max(-4.0, r_energy)
         r_fairness = (jain_idx - 1.0 / K) / max(1.0 - 1.0 / K, 1e-10) * 4.0 + 0.5


### PR DESCRIPTION
## Summary
Combines multiplier rescale `* 4.0 / num_uavs` with the ADR-0009 soft floor. M=2 fix-floor checkpoint is no longer bit-identical (multiplier changed for M=2 too); old M=4 ADR-0009 pilot was killed at 360K after policy collapse.

## Why
The M=4 pilot under ADR-0009 (soft-floor-only) climbed to HV=204B at 180K then **collapsed back to HV=0 by 340-360K**. mean r3 went monotonically -168 → -498 → -528 → -739 → -692 → -781.

Reframing ADR-0009: the soft floor capped the worst-case magnitude (-11.5 → -4) but didn't reduce the **gradient strength** of the energy term relative to other reward components. At M=4, per-step penalty up to 4× the other rewards' range was enough to dominate updates once SAC entropy decayed → degenerate attractor.

## Fix
Per-step ranges (uniform size = 4 across all M, vs old size = 8 (M=2) up to 16 (M=4) under ADR-0008/9):

| M | range | coord. gradient |
|---|------|---|
| 1 | [0.5, 4.5] | N/A (single-UAV untouched) |
| 2 | [-1.5, 2.5] | 2.0/step (was 4.0) |
| 4 | [-2.5, 1.5] | 3.0/step (was 12.0) ← Goldilocks |
| 5 | [-2.7, 1.3] | 3.2/step (was 16.0) |

Soft floor at -4.0 stays as a safety cap (now dead code in expected operating regimes).

## What's invalidated
- `pilot-M2-fixfloor-seed1` ← no longer bit-identical (multiplier changed). Becomes "ADR-0009 reference" data point. **Need to re-run M=2 under ADR-0010**.
- `pilot-M4-softfloor-seed1` ← already invalid (killed at 360K). `policy_3.pkl` preserved as ablation point #5.

## Test plan
- [x] M=1 single-UAV class is untouched (bit-identical)
- [x] ADR-0010 documents diagnostic + per-M range table + 5-point ablation list
- [ ] Re-run M=2 with `--exp_name pilot-M2-rescaled-seed1` (~5h)
- [ ] Re-run M=4 with `--exp_name pilot-M4-rescaled-seed1` (~5h, sequential since 1 GPU)
- [ ] Diagnose both. Expect: M=2 HV ≥ 400B, M=4 HV ≥ 100B stable

## Risk gating
If M=4 also fails under ADR-0010, escalation paths captured in the ADR:
- F. Curriculum (M=2 warm-start)
- G. Split r3 into per-UAV + fleet-level signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)