### PR TITLE
feat(cli): expose --entropy_tuning flag for fixed-alpha SAC

### DIFF
--- a/main_uav.py
+++ b/main_uav.py
@@ -106,7 +106,14 @@ def run():
     parser.add_argument("--num_steps", type=int, default=2000000)
     parser.add_argument("--batch_size", type=int, default=256)
     parser.add_argument("--gamma", type=float, default=0.99)
-    parser.add_argument("--ent_coef", type=float, default=0.2)
+    parser.add_argument("--ent_coef", type=float, default=0.2,
+                        help="SAC entropy coefficient. Used as fixed alpha when "
+                             "--no-entropy_tuning, else as the initial alpha.")
+    parser.add_argument(
+        "--entropy_tuning", action=argparse.BooleanOptionalAction, default=True,
+        help="Auto-tune SAC entropy alpha to target -|A|. Disable with "
+             "--no-entropy_tuning to use a fixed --ent_coef (lower alpha "
+             "stabilises large-M training where target -|A| over-explores).")
     parser.add_argument("--eval_interval", type=int, default=20000)
 
     # --- latent encoder ---
@@ -205,7 +212,7 @@ def run():
         "buf_num": args.buf_num,
         "gamma": args.gamma,
         "tau": 0.005,
-        "entropy_tuning": True,
+        "entropy_tuning": args.entropy_tuning,
         "ent_coef": args.ent_coef,
         "multi_step": 1,
         "per": False,


### PR DESCRIPTION
## Summary
1-line CLI exposure of an existing agent.py knob. Lets us launch with `--no-entropy_tuning --ent_coef 0.05` to disable auto-tuned alpha for large-M instability investigation. Single-UAV / M=2 default is unchanged (entropy_tuning=True remains the default).

## Why
Both ADR-0009 and ADR-0010 M=4 pilots collapsed in the same pattern: HV climbs to ~125-200B at 180K, then drifts down to 0 by 360-720K. Reward-shape mitigations alone did not fix it.

Hypothesis: auto-tuned alpha targets `entropy = -|A|`. At M=4 with action_dim=68, target is -68 (vs -12 for single-UAV). After the agent finds a low-entropy coordinated policy at ~180K, alpha auto-tunes upward to drag entropy back to the -68 target → policy diverges from the coordinated attractor.

Disabling auto-tuning + fixed low alpha is the cheapest test of this hypothesis (no code change beyond CLI plumbing). If it works, M=4 should reach a stable HV ≥ 100B.

## Test plan
- [x] Single-UAV / M=2 default behaviour unchanged (entropy_tuning=True remains default)
- [ ] Launch M=4 with `--no-entropy_tuning --ent_coef 0.05` and observe whether the post-180K collapse is gone
- [ ] If yes → entropy decay schedule becomes a proper tunable; if no → escalate to curriculum (option F in ADR-0010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)